### PR TITLE
Ensure thumbnail worker is deleted when thread ends

### DIFF
--- a/thumbnail_viewer.py
+++ b/thumbnail_viewer.py
@@ -60,6 +60,7 @@ class ImageListModel(QtCore.QAbstractListModel):
         self._worker = ThumbnailWorker()
         self._worker.moveToThread(self._thread)
         self._thread.started.connect(self._worker.load_next)
+        self._thread.finished.connect(self._worker.deleteLater)
         self.request_thumbnail.connect(self._worker.enqueue)
         self._worker.loaded.connect(self._on_loaded)
 


### PR DESCRIPTION
## Summary
- delete the thumbnail worker after the thread stops to avoid leaks

## Testing
- `python -m py_compile thumbnail_viewer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c014137048324a82b315cb716b83b